### PR TITLE
No image bug fixed.

### DIFF
--- a/lib/providers/chat_provider.dart
+++ b/lib/providers/chat_provider.dart
@@ -6,11 +6,7 @@ class ChatProvider extends ChangeNotifier {
   final ScrollController chatScrollController = ScrollController();
   final ApiYesNoWtf apiYesNoWtf = ApiYesNoWtf();
 
-  List<Message> messageList = [
-    Message(text: '¡Hola!', fromWho: FromWho.me),
-    Message(text: '¿Me das dinero?', fromWho: FromWho.me),
-    Message(text: 'No', fromWho: FromWho.friend),
-  ];
+  List<Message> messageList = [];
 
   Future<void> friendReply() async {
     final Message friendMessage = await apiYesNoWtf.getYesNoAnswer();

--- a/lib/widgets/chat_bubbles/friend_message_bubble.dart
+++ b/lib/widgets/chat_bubbles/friend_message_bubble.dart
@@ -32,7 +32,9 @@ class FriendMessageBubble extends StatelessWidget {
           ),
         ),
         const SizedBox(height: 5.0),
-        ImageBubble(imageUrl: message.imageUrl!),
+        ImageBubble(
+            imageUrl: message.imageUrl ??
+                'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQE3CETL_OertJKScoHfblxs6CBrKGVCmVESw'),
         const SizedBox(height: 10.0),
       ],
     );


### PR DESCRIPTION
- messageList from chat_provider now has not preloaded messages.
- If preloaded messages existed for "friend" and no image was passed, an exception was thrown by the app. This is now fixed loading a "No image available" image if no image is passed to "friend" messages.